### PR TITLE
Optimize default vhost removal. Add support for removing default ssl vhost from ssl.conf on CentOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ The wcm.io fork adds the following features on top of the original functionality
     * `apache_listen_port` and `apache_listen_port_ssl` support on Debian, RedHat/Amazon Linux and SUSE
     * `apache_mods_enabled` support on Debian, RedHat/Amazon Linux and SUSE.
 
+* Issue https://github.com/geerlingguy/ansible-role-apache/issues/81
+* Issue https://github.com/geerlingguy/ansible-role-apache/issues/21
+
 **Namespace**
 
 This role is published within the `wcm-io-devops` namespace.
@@ -53,7 +56,11 @@ If set to true, a vhosts file, managed by this role's variables (see below), wil
 
     apache_remove_default_vhost: false
 
-On Debian/Ubuntu, a default virtualhost is included in Apache's configuration. Set this to `true` to remove that default virtualhost configuration file.
+On Debian/Ubuntu RedHat/CentOS, default virtualhosts are included in Apache's configuration. Set this to `true` to remove that default virtualhost configuration file.
+
+    apache_remove_default_vhost_ssl: false
+
+On RedHat/CentOS based systems a default virtualhost is present in the ssl.conf. Set this to `true` to remove that virtualhost from ssl.conf configuration file.
 
     apache_global_vhost_settings: |
       DirectoryIndex index.php index.html

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,6 +14,10 @@ apache_vhosts_template: "vhosts.conf.j2"
 # Set this to `true` to remove that default.
 apache_remove_default_vhost: false
 
+# Delete default SSL virtualhost files includes in Apache's configuration
+# This currently only has an effect on RedHat based OS, where the default virtualhost is removed from ssl.conf
+apache_remove_default_vhost_ssl: false
+
 apache_global_vhost_settings: |
   DirectoryIndex index.php index.html
 

--- a/tasks/configure-Debian.yml
+++ b/tasks/configure-Debian.yml
@@ -57,7 +57,8 @@
 
 - name: Remove default vhost in sites-enabled.
   file:
-    path: "{{ apache_conf_path }}/sites-enabled/{{ apache_default_vhost_filename }}"
+    path: "{{ apache_conf_path }}/sites-enabled/{{ item }}"
     state: absent
   notify: restart apache
+  with_items: "{{ apache_default_vhost_filenames }}"
   when: apache_remove_default_vhost

--- a/tasks/configure-RedHat.yml
+++ b/tasks/configure-RedHat.yml
@@ -30,7 +30,7 @@
 
 - name: Configure Apache ssl.conf (replace).
   replace:
-    dest: "{{ apache_server_root }}/conf.d/ssl.conf"
+    dest: "{{ apache_conf_path }}/ssl.conf"
     regexp: "{{ item.regexp }}"
     replace: "{{ item.replace }}"
   with_items: "{{ apache_ports_configuration_items }}"
@@ -53,3 +53,18 @@
     mode: 0644
   notify: restart apache
   when: apache_create_vhosts
+
+- name: Remove default vhost configurations
+  file:
+    path: "{{ apache_conf_path }}/{{ item }}"
+    state: absent
+  notify: restart apache
+  with_items: "{{ apache_default_vhost_filenames }}"
+  when: apache_remove_default_vhost
+
+- name: Remove default ssl vhost configurations
+  replace:
+    dest: "{{ apache_conf_path }}/ssl.conf"
+    regexp: "##\\n##\\s*SSL Virtual Host Context(.*\\n)*</VirtualHost>"
+  when: apache_remove_default_vhost_ssl
+  notify: restart apache

--- a/vars/apache-22.yml
+++ b/vars/apache-22.yml
@@ -1,6 +1,10 @@
 ---
 apache_vhosts_version: "2.2"
-apache_default_vhost_filename: 000-default
+apache_default_vhost_filenames:
+  - 000-default
+  - welcome.conf
+  - userdir.conf
+  - autoindex.conf
 
 apache_ports_configuration_items:
   # Debian, Ubuntu and RedHat

--- a/vars/apache-24.yml
+++ b/vars/apache-24.yml
@@ -1,6 +1,10 @@
 ---
 apache_vhosts_version: "2.4"
-apache_default_vhost_filename: 000-default.conf
+apache_default_vhost_filenames:
+  - 000-default.conf
+  - welcome.conf
+  - userdir.conf
+  - autoindex.conf
 
 apache_ports_configuration_items:
   # Debian/Ubuntu and RedHat/CentOS/Amazon Linux Regex for http


### PR DESCRIPTION
This PR addresses:
* https://github.com/geerlingguy/ansible-role-apache/issues/81
* https://github.com/geerlingguy/ansible-role-apache/issues/21

It is based on the PR: https://github.com/geerlingguy/ansible-role-apache/pull/131
but it does only alter the ssl.conf on RedHat based systems and keeps the ssl.conf in place.