### PR TITLE
Skip localhost.crt tasks in rhel 8 if apache_remove_default_vhost_ssl: true

### DIFF
--- a/tasks/configure-RedHat.yml
+++ b/tasks/configure-RedHat.yml
@@ -24,13 +24,16 @@
   stat:
     path: /etc/pki/tls/certs/localhost.crt
   register: localhost_cert
-  when: ansible_distribution_major_version | int >= 8
+  when:
+    - ansible_distribution_major_version | int >= 8
+    - not apache_remove_default_vhost_ssl
 
 - name: Ensure httpd certs are installed (RHEL 8 and later).
   command: /usr/libexec/httpd-ssl-gencerts
   when:
     - ansible_distribution_major_version | int >= 8
     - not localhost_cert.stat.exists
+    - not apache_remove_default_vhost_ssl
 
 - name: Enable Apache mods.
   apache2_module:


### PR DESCRIPTION
During a new deployment of a service I noticed the role not being idempotent if `apache_remove_default_vhost_ssl` is set to true as the tasks:
- Check if localhost cert exists (RHEL 8 and later).
- Ensure httpd certs are installed (RHEL 8 and later).

are always executed. This is due to `/usr/libexec/httpd-ssl-gencerts` skipping the localhost.crt generation if the `ssl.conf` does not match any of the criteria in the following block
```
if ! test -f ${ssldotconf} || \
   ! grep -q '^SSLCertificateFile /etc/pki/tls/certs/localhost.crt' ${ssldotconf} || \                                                 
   ! grep -q '^SSLCertificateKeyFile /etc/pki/tls/private/localhost.key' ${ssldotconf}; then                                           
    # Non-default configuration, do nothing.
    exit 0
fi
```

My understanding is that if the variable `apache_remove_default_vhost_ssl` is set to `true` those tasks can be skipped as most likely the certificates are handled somewhere else in a playbook so the two tasks dealing with `localhost.crt` could be skipped.
