### PR TITLE
Support check mode

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -45,6 +45,7 @@
   changed_when: false
   ignore_errors: true
   register: _apache_syntax_check_output
+  when: not ansible_check_mode
 
 - name: Print error and exit if the apache config syntax check failed.
   block:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -58,7 +58,7 @@
       fail:
         msg: Apache config syntax check (apachectl -t) failed . Exiting now to avoid a crash when restarting the daemon
 
-  when: _apache_syntax_check_output.rc != 0
+  when: not ansible_check_mode and _apache_syntax_check_output.rc != 0
 
 - name: Ensure Apache has selected state and enabled on boot.
   service:


### PR DESCRIPTION
This role uses a command task, and then it checks the command output. In check mode, the command is not run, thus the next task that checks output fails.

This PR:
  - Avoids running the command task in check mode (because we are in check mode, no changes have been made, so there''s no point to test the config because it would check not the role deployed config but something else).
 -  Avoid checking the command output in check mode.